### PR TITLE
feat: add interactive buttons to the daily Telegram quote

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 DailyQuoteBot is a stateless script that fetches a random quote from a Notion database and sends it to a Telegram chat once a day via a Telegram bot. It runs as a GitHub Actions cron job — there is no long-running server.
 
+Each quote carries inline buttons (Favorite toggle, Put back in cycle, Delete, Send another). Because button taps need something listening — which the cron job is not — taps are handled by a separate **Vercel Python serverless function** (`api/telegram.py`) registered as the bot's webhook.
+
 ## Running the service
 
 Run from the repo root with `PYTHONPATH` set to the repo root (the code uses
@@ -33,16 +35,25 @@ Single-shot script (`src/run_daily_service.py`) invoked by GitHub Actions cron (
 
 1. `daily_service/notion.py` — picks a random "eligible" quote from Notion. A quote is eligible if its `Send Date` field is empty or older than `refresh_window_months` (default: 3). When no eligible quotes remain, all `Send Date` fields are cleared and the cycle restarts.
 2. `daily_service/utils.py::format_response` — extracts quote text, author, and optional Cover image URL from the Notion page properties, and builds the message body with the Notion **page** URL (`quote["url"]`) as the trailing link. Telegram auto-links the bare URL, so it is used as-is. (The Cover image URL is returned separately as the media attachment.) `shorten_url` (TinyURL v2) is retained in this module but no longer called.
-3. `daily_service/telegram.py::send_telegram` — sends via the **pyTelegramBotAPI** SDK (`telebot`). If a Cover image is present and the caption fits within 1024 chars, it sends a single `send_photo` with caption; otherwise it sends the photo and text as separate messages. Text messages set `disable_web_page_preview=True`. Longer-than-4096-char bodies are chunked.
+3. `daily_service/telegram.py::send_telegram` — sends via the **pyTelegramBotAPI** SDK (`telebot`). If a Cover image is present and the caption fits within 1024 chars, it sends a single `send_photo` with caption; otherwise it sends the photo and text as separate messages. Text messages set `disable_web_page_preview=True`. Longer-than-4096-char bodies are chunked. A `reply_markup` keyboard (from `build_quote_keyboard`) is attached to the message.
 4. `daily_service/notion.py::update_used_quotes` — stamps `Send Date` = today on the picked page so it won't be reselected within the refresh window.
+
+Steps 1–4 are wrapped by `daily_service/service.py::pick_and_send`, shared by the cron entry point (`run_daily_service.py`) and the webhook's "Send another now" button.
+
+**Webhook (`api/telegram.py`, on Vercel)** — receives Telegram callback queries. It verifies the `X-Telegram-Bot-Api-Secret-Token` header against `TELEGRAM_WEBHOOK_SECRET`, ignores taps whose sender id != `TELEGRAM_CHAT_ID`, then `handle_update` dispatches on `callback_data`:
+- `fav:<page_id>` — toggles the `Favorite` checkbox (reads current state, flips it) and edits the message keyboard to flip the button label.
+- `cycle:<page_id>` — clears `Send Date` (`clear_send_date`) so the quote is eligible again.
+- `del:<page_id>` — sets the `Deleted` checkbox (`set_deleted`) and removes the buttons.
+- `more` — runs `pick_and_send` to deliver another quote.
+Every path answers the callback so the button spinner stops. `vercel.json` includes `src/**` so the function can import the shared package.
 
 **Notion DB schema** expected by the code:
 - `Quote` (title field) — quote text
 - `Author` (rich_text) — author name
 - `Cover` (files) — optional image
 - `Send Date` (date) — tracks when the quote was last sent
-
-The `Favorite` checkbox property exists in the DB but is no longer read or written by the code.
+- `Favorite` (checkbox) — toggled by the Favorite button
+- `Deleted` (checkbox) — set by the Delete button; soft-deleted quotes are excluded from selection (`get_unsent_quotes` filters `Deleted == false`)
 
 ## Telegram notes
 
@@ -51,6 +62,18 @@ Delivery is via a Telegram bot using the **pyTelegramBotAPI** (`telebot`) SDK:
 - A bot cannot initiate a chat — the recipient must message the bot once first. The recipient's numeric id (`TELEGRAM_CHAT_ID`) comes from `https://api.telegram.org/bot<TOKEN>/getUpdates` or [@userinfobot](https://t.me/userinfobot).
 - Unlike the old Twilio WhatsApp sandbox, there is no session/opt-in window that lapses, so no reply-reminder is needed.
 - Telegram limits: 4096 chars per text message, 1024 chars per photo caption — both handled in `telegram.py`.
+
+### Buttons / webhook (Vercel)
+
+Button taps are handled by `api/telegram.py`, deployed as a Vercel Python serverless function and registered as the bot's webhook. It needs these env vars set **in Vercel** (separate from the GitHub Actions secrets used by the cron): `NOTION_TOKEN`, `NOTION_DB_ID`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, and `TELEGRAM_WEBHOOK_SECRET` (any random string; also passed as the `secret_token` when registering the webhook).
+
+Register the webhook once after deploy:
+
+```bash
+curl "https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/setWebhook" \
+  -d "url=https://<your-app>.vercel.app/api/telegram" \
+  -d "secret_token=<TELEGRAM_WEBHOOK_SECRET>"
+```
 
 ## Deployment
 

--- a/api/telegram.py
+++ b/api/telegram.py
@@ -1,0 +1,89 @@
+import os
+import sys
+import json
+from http.server import BaseHTTPRequestHandler
+
+import telebot
+from notion_client import Client
+
+# Make the shared src package importable when bundled on Vercel.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.daily_service.consts import DEFAULT_REFRESH_WINDOW_MONTHS
+from src.daily_service.telegram import build_quote_keyboard
+from src.daily_service.service import pick_and_send
+from src.daily_service.notion import (get_favorite, set_favorite,
+                                       clear_send_date, set_deleted)
+
+
+def handle_update(update, notion_client, bot, chat_id, notion_db_id,
+                  bot_token, refresh_window_months) -> None:
+    """Dispatch a single Telegram update. Only callback-query taps from the
+    configured chat are acted on; every path answers the callback so the button
+    spinner stops."""
+    cq = update.callback_query
+    if cq is None:
+        return
+
+    # Only the configured recipient may drive the buttons.
+    if str(cq.from_user.id) != str(chat_id):
+        bot.answer_callback_query(cq.id, "Not authorized")
+        return
+
+    action, _, page_id = (cq.data or "").partition(":")
+    msg_chat = cq.message.chat.id
+    msg_id = cq.message.message_id
+
+    if action == "fav":
+        new_value = not get_favorite(notion_client, page_id)
+        set_favorite(notion_client, page_id, new_value)
+        bot.edit_message_reply_markup(
+            chat_id=msg_chat, message_id=msg_id,
+            reply_markup=build_quote_keyboard(page_id, new_value))
+        bot.answer_callback_query(cq.id,
+                                  "⭐ Favorited" if new_value else "☆ Removed from favorites")
+    elif action == "cycle":
+        clear_send_date(notion_client, page_id)
+        bot.answer_callback_query(cq.id, "🔁 Put back in cycle")
+    elif action == "del":
+        set_deleted(notion_client, page_id, True)
+        bot.edit_message_reply_markup(chat_id=msg_chat, message_id=msg_id, reply_markup=None)
+        bot.answer_callback_query(cq.id, "🗑 Deleted")
+    elif action == "more":
+        pick_and_send(notion_client=notion_client, notion_db_id=notion_db_id,
+                      bot_token=bot_token, chat_id=chat_id,
+                      refresh_window_months=refresh_window_months)
+        bot.answer_callback_query(cq.id, "➕ Sent another")
+    else:
+        bot.answer_callback_query(cq.id)
+
+
+class handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        # Reject anything not carrying Telegram's secret token.
+        secret = os.environ["TELEGRAM_WEBHOOK_SECRET"]
+        if self.headers.get("X-Telegram-Bot-Api-Secret-Token") != secret:
+            self.send_response(401)
+            self.end_headers()
+            return
+
+        length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(length).decode("utf-8") if length else "{}"
+
+        try:
+            update = telebot.types.Update.de_json(json.loads(body))
+            bot = telebot.TeleBot(os.environ["TELEGRAM_BOT_TOKEN"])
+            notion_client = Client(auth=os.environ["NOTION_TOKEN"])
+            refresh = int(os.environ.get("REFRESH_WINDOW_MONTHS",
+                                         DEFAULT_REFRESH_WINDOW_MONTHS))
+            handle_update(update, notion_client, bot,
+                          chat_id=os.environ["TELEGRAM_CHAT_ID"],
+                          notion_db_id=os.environ["NOTION_DB_ID"],
+                          bot_token=os.environ["TELEGRAM_BOT_TOKEN"],
+                          refresh_window_months=refresh)
+        except Exception as e:
+            print(f"Webhook error: {e}")
+
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"ok")

--- a/src/daily_service/notion.py
+++ b/src/daily_service/notion.py
@@ -22,17 +22,27 @@ def get_unsent_quotes(notion_client: Client, notion_db_id: str, refresh_window_m
     response = notion_client.databases.query(
         database_id=notion_db_id,
         filter={
-            "or": [
+            "and": [
                 {
-                    "property": "Send Date",
-                    "date": {
-                        "before": before_date.isoformat()
-                    }
+                    "or": [
+                        {
+                            "property": "Send Date",
+                            "date": {
+                                "before": before_date.isoformat()
+                            }
+                        },
+                        {
+                            "property": "Send Date",
+                            "date": {
+                                "is_empty": True
+                            }
+                        }
+                    ]
                 },
                 {
-                    "property": "Send Date",
-                    "date": {
-                        "is_empty": True
+                    "property": "Deleted",
+                    "checkbox": {
+                        "equals": False
                     }
                 }
             ]
@@ -67,4 +77,30 @@ def update_used_quotes(notion_client: Client, quote: dict) -> None:
                 }
             }
         }
+    )
+
+
+def get_favorite(notion_client: Client, page_id: str) -> bool:
+    page = notion_client.pages.retrieve(page_id=page_id)
+    return bool(page.get("properties", {}).get("Favorite", {}).get("checkbox", False))
+
+
+def set_favorite(notion_client: Client, page_id: str, value: bool) -> None:
+    notion_client.pages.update(
+        page_id=page_id,
+        properties={"Favorite": {"checkbox": value}}
+    )
+
+
+def clear_send_date(notion_client: Client, page_id: str) -> None:
+    notion_client.pages.update(
+        page_id=page_id,
+        properties={"Send Date": {"date": None}}
+    )
+
+
+def set_deleted(notion_client: Client, page_id: str, value: bool = True) -> None:
+    notion_client.pages.update(
+        page_id=page_id,
+        properties={"Deleted": {"checkbox": value}}
     )

--- a/src/daily_service/service.py
+++ b/src/daily_service/service.py
@@ -1,0 +1,26 @@
+from notion_client import Client
+
+from src.daily_service.utils import format_response
+from src.daily_service.telegram import send_telegram, build_quote_keyboard
+from src.daily_service.notion import get_next_quote, update_used_quotes
+
+
+def _is_favorite(quote: dict) -> bool:
+    return bool(quote.get("properties", {}).get("Favorite", {}).get("checkbox", False))
+
+
+def pick_and_send(notion_client: Client, notion_db_id: str, bot_token: str,
+                  chat_id: str, refresh_window_months: int) -> None:
+    """Core daily-send flow, shared by the cron entry point and the webhook's
+    'Send another now' button."""
+    next_quote = get_next_quote(notion_client=notion_client, notion_db_id=notion_db_id,
+                                refresh_window_months=refresh_window_months)
+    if next_quote:
+        message, media_url = format_response(next_quote)
+        keyboard = build_quote_keyboard(next_quote["id"], _is_favorite(next_quote))
+        send_telegram(msg=message, media_url=media_url, bot_token=bot_token,
+                      chat_id=chat_id, reply_markup=keyboard)
+        update_used_quotes(notion_client, next_quote)
+    else:
+        send_telegram(msg="⚠️ No sentences found in Notion.", media_url=None,
+                      bot_token=bot_token, chat_id=chat_id)

--- a/src/daily_service/telegram.py
+++ b/src/daily_service/telegram.py
@@ -3,24 +3,47 @@ import telebot
 from src.daily_service.consts import Telegram
 
 
-def send_telegram(msg: str, media_url: str | None, bot_token: str, chat_id: str) -> None:
+def build_quote_keyboard(page_id: str, is_favorite: bool) -> "telebot.types.InlineKeyboardMarkup":
+    """Inline keyboard attached to each quote. The favorite button toggles, so its
+    label reflects the current state."""
+    markup = telebot.types.InlineKeyboardMarkup()
+    fav_label = "☆ Unfavorite" if is_favorite else "⭐ Favorite"
+    markup.row(
+        telebot.types.InlineKeyboardButton(fav_label, callback_data=f"fav:{page_id}"),
+        telebot.types.InlineKeyboardButton("🔁 Put back", callback_data=f"cycle:{page_id}"),
+    )
+    markup.row(
+        telebot.types.InlineKeyboardButton("🗑 Delete", callback_data=f"del:{page_id}"),
+        telebot.types.InlineKeyboardButton("➕ Send another", callback_data="more"),
+    )
+    return markup
+
+
+def send_telegram(msg: str, media_url: str | None, bot_token: str, chat_id: str,
+                  reply_markup=None) -> None:
     bot = telebot.TeleBot(bot_token)
 
     try:
         if media_url and len(msg) <= Telegram.CAPTION_TEXT_LENGTH_LIMIT:
-            bot.send_photo(chat_id, photo=media_url, caption=msg, parse_mode="HTML")
+            bot.send_photo(chat_id, photo=media_url, caption=msg, parse_mode="HTML",
+                           reply_markup=reply_markup)
         elif media_url:
             bot.send_photo(chat_id, photo=media_url)
-            for chunk in split_message(msg):
-                bot.send_message(chat_id, chunk, parse_mode="HTML",
-                                 disable_web_page_preview=True)
+            _send_text_chunks(bot, chat_id, msg, reply_markup)
         else:
-            for chunk in split_message(msg):
-                bot.send_message(chat_id, chunk, parse_mode="HTML",
-                                 disable_web_page_preview=True)
+            _send_text_chunks(bot, chat_id, msg, reply_markup)
         print("Message sent successfully!")
     except Exception as e:
         print(f"Failed to send message: {e}")
+
+
+def _send_text_chunks(bot, chat_id: str, msg: str, reply_markup) -> None:
+    """Send the body as one or more chunks, attaching the keyboard to the last one."""
+    chunks = split_message(msg)
+    for i, chunk in enumerate(chunks):
+        markup = reply_markup if i == len(chunks) - 1 else None
+        bot.send_message(chat_id, chunk, parse_mode="HTML",
+                         disable_web_page_preview=True, reply_markup=markup)
 
 
 def split_message(message: str) -> list[str]:

--- a/src/run_daily_service.py
+++ b/src/run_daily_service.py
@@ -6,10 +6,8 @@ from notion_client import Client
 
 load_dotenv('../.env')
 
-from src.daily_service.utils import format_response
-from src.daily_service.telegram import send_telegram
 from src.daily_service.consts import DEFAULT_REFRESH_WINDOW_MONTHS
-from src.daily_service.notion import get_next_quote, update_used_quotes
+from src.daily_service.service import pick_and_send
 
 
 NOTION_TOKEN = os.environ['NOTION_TOKEN']
@@ -20,16 +18,9 @@ TELEGRAM_CHAT_ID = os.environ['TELEGRAM_CHAT_ID']
 
 def main(refresh_window_months: int) -> None:
     notion_client = Client(auth=NOTION_TOKEN)
-    next_quote = get_next_quote(notion_client=notion_client, notion_db_id=NOTION_DB_ID,
-                                refresh_window_months=refresh_window_months)
-    if next_quote:
-        message, media_url = format_response(next_quote)
-        send_telegram(msg=message, media_url=media_url,
-                      bot_token=TELEGRAM_BOT_TOKEN, chat_id=TELEGRAM_CHAT_ID)
-        update_used_quotes(notion_client, next_quote)
-    else:
-        send_telegram(msg="⚠️ No sentences found in Notion.", media_url=None,
-                      bot_token=TELEGRAM_BOT_TOKEN, chat_id=TELEGRAM_CHAT_ID)
+    pick_and_send(notion_client=notion_client, notion_db_id=NOTION_DB_ID,
+                  bot_token=TELEGRAM_BOT_TOKEN, chat_id=TELEGRAM_CHAT_ID,
+                  refresh_window_months=refresh_window_months)
 
 
 if __name__ == "__main__":

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -8,6 +8,10 @@ from src.daily_service.notion import (
     get_unsent_quotes,
     reset_quotes_tracker,
     update_used_quotes,
+    get_favorite,
+    set_favorite,
+    clear_send_date,
+    set_deleted,
 )
 
 
@@ -34,9 +38,14 @@ def test_get_unsent_quotes_filters_by_send_date_before_and_empty():
     expected_before = (datetime.date.today() - relativedelta(months=3)).isoformat()
     filter_ = call_kwargs["filter"]
     assert filter_ == {
-        "or": [
-            {"property": "Send Date", "date": {"before": expected_before}},
-            {"property": "Send Date", "date": {"is_empty": True}},
+        "and": [
+            {
+                "or": [
+                    {"property": "Send Date", "date": {"before": expected_before}},
+                    {"property": "Send Date", "date": {"is_empty": True}},
+                ]
+            },
+            {"property": "Deleted", "checkbox": {"equals": False}},
         ]
     }
 
@@ -92,4 +101,51 @@ def test_update_used_quotes_stamps_today_on_the_picked_page():
     client.pages.update.assert_called_once_with(
         page_id="picked-1",
         properties={"Send Date": {"date": {"start": today_iso}}},
+    )
+
+
+def test_get_favorite_reads_checkbox():
+    client = MagicMock()
+    client.pages.retrieve.return_value = {
+        "properties": {"Favorite": {"checkbox": True}}
+    }
+
+    assert get_favorite(client, "page-1") is True
+    client.pages.retrieve.assert_called_once_with(page_id="page-1")
+
+
+def test_get_favorite_defaults_false_when_missing():
+    client = MagicMock()
+    client.pages.retrieve.return_value = {"properties": {}}
+
+    assert get_favorite(client, "page-1") is False
+
+
+def test_set_favorite_updates_checkbox():
+    client = MagicMock()
+
+    set_favorite(client, "page-1", True)
+
+    client.pages.update.assert_called_once_with(
+        page_id="page-1", properties={"Favorite": {"checkbox": True}}
+    )
+
+
+def test_clear_send_date_sets_date_none():
+    client = MagicMock()
+
+    clear_send_date(client, "page-1")
+
+    client.pages.update.assert_called_once_with(
+        page_id="page-1", properties={"Send Date": {"date": None}}
+    )
+
+
+def test_set_deleted_defaults_true():
+    client = MagicMock()
+
+    set_deleted(client, "page-1")
+
+    client.pages.update.assert_called_once_with(
+        page_id="page-1", properties={"Deleted": {"checkbox": True}}
     )

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch, call
 
-from src.daily_service.telegram import send_telegram, split_message
+from src.daily_service.telegram import (send_telegram, split_message,
+                                        build_quote_keyboard)
 from src.daily_service.consts import Telegram
 
 
@@ -39,7 +40,7 @@ def test_send_telegram_media_with_short_caption_sends_single_photo(MockTeleBot):
 
     MockTeleBot.assert_called_once_with(BOT_TOKEN)
     bot.send_photo.assert_called_once_with(
-        CHAT_ID, photo=media_url, caption=msg, parse_mode="HTML"
+        CHAT_ID, photo=media_url, caption=msg, parse_mode="HTML", reply_markup=None
     )
     bot.send_message.assert_not_called()
 
@@ -80,7 +81,8 @@ def test_send_telegram_text_only_short_sends_single_message(MockTeleBot):
     send_telegram("hi", None, BOT_TOKEN, CHAT_ID)
 
     bot.send_message.assert_called_once_with(
-        CHAT_ID, "hi", parse_mode="HTML", disable_web_page_preview=True
+        CHAT_ID, "hi", parse_mode="HTML", disable_web_page_preview=True,
+        reply_markup=None
     )
     bot.send_photo.assert_not_called()
 
@@ -94,3 +96,36 @@ def test_send_telegram_swallows_errors(MockTeleBot, capsys):
 
     captured = capsys.readouterr()
     assert "Failed to send message" in captured.out
+
+
+@patch("src.daily_service.telegram.telebot.TeleBot")
+def test_send_telegram_passes_reply_markup_to_photo(MockTeleBot):
+    bot = MockTeleBot.return_value
+    markup = object()
+
+    send_telegram("cap", "https://example.com/img.png", BOT_TOKEN, CHAT_ID,
+                  reply_markup=markup)
+
+    assert bot.send_photo.call_args.kwargs["reply_markup"] is markup
+
+
+def _flatten(markup):
+    return [btn for row in markup.keyboard for btn in row]
+
+
+def test_build_quote_keyboard_not_favorite_shows_favorite_label():
+    markup = build_quote_keyboard("page-1", is_favorite=False)
+    buttons = _flatten(markup)
+
+    by_data = {b.callback_data: b.text for b in buttons}
+    assert by_data["fav:page-1"] == "⭐ Favorite"
+    assert "cycle:page-1" in by_data
+    assert "del:page-1" in by_data
+    assert "more" in by_data
+
+
+def test_build_quote_keyboard_favorite_shows_unfavorite_label():
+    markup = build_quote_keyboard("page-1", is_favorite=True)
+    fav_btn = next(b for b in _flatten(markup) if b.callback_data == "fav:page-1")
+
+    assert fav_btn.text == "☆ Unfavorite"

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,99 @@
+from unittest.mock import MagicMock, patch
+
+import telebot
+
+from api.telegram import handle_update
+
+
+CHAT_ID = "12345"
+DB_ID = "db-1"
+BOT_TOKEN = "tok"
+
+
+def _update(data, from_id=int(CHAT_ID)):
+    return telebot.types.Update.de_json({
+        "update_id": 1,
+        "callback_query": {
+            "id": "cb-1",
+            "from": {"id": from_id, "is_bot": False, "first_name": "U"},
+            "chat_instance": "ci",
+            "message": {
+                "message_id": 99,
+                "date": 0,
+                "chat": {"id": int(CHAT_ID), "type": "private"},
+            },
+            "data": data,
+        },
+    })
+
+
+def _dispatch(update, notion_client, bot):
+    handle_update(update, notion_client, bot, chat_id=CHAT_ID, notion_db_id=DB_ID,
+                  bot_token=BOT_TOKEN, refresh_window_months=3)
+
+
+def test_favorite_toggles_on_and_edits_keyboard():
+    notion = MagicMock()
+    notion.pages.retrieve.return_value = {"properties": {"Favorite": {"checkbox": False}}}
+    bot = MagicMock()
+
+    _dispatch(_update("fav:page-1"), notion, bot)
+
+    notion.pages.update.assert_called_once_with(
+        page_id="page-1", properties={"Favorite": {"checkbox": True}}
+    )
+    bot.edit_message_reply_markup.assert_called_once()
+    bot.answer_callback_query.assert_called_once()
+    assert "Favorited" in bot.answer_callback_query.call_args.args[1]
+
+
+def test_cycle_clears_send_date():
+    notion = MagicMock()
+    bot = MagicMock()
+
+    _dispatch(_update("cycle:page-1"), notion, bot)
+
+    notion.pages.update.assert_called_once_with(
+        page_id="page-1", properties={"Send Date": {"date": None}}
+    )
+    bot.answer_callback_query.assert_called_once()
+
+
+def test_delete_sets_flag_and_removes_buttons():
+    notion = MagicMock()
+    bot = MagicMock()
+
+    _dispatch(_update("del:page-1"), notion, bot)
+
+    notion.pages.update.assert_called_once_with(
+        page_id="page-1", properties={"Deleted": {"checkbox": True}}
+    )
+    bot.edit_message_reply_markup.assert_called_once_with(
+        chat_id=int(CHAT_ID), message_id=99, reply_markup=None
+    )
+    bot.answer_callback_query.assert_called_once()
+
+
+@patch("api.telegram.pick_and_send")
+def test_more_sends_another_quote(mock_pick_and_send):
+    notion = MagicMock()
+    bot = MagicMock()
+
+    _dispatch(_update("more"), notion, bot)
+
+    mock_pick_and_send.assert_called_once()
+    assert mock_pick_and_send.call_args.kwargs["notion_db_id"] == DB_ID
+    bot.answer_callback_query.assert_called_once()
+
+
+def test_tap_from_wrong_user_is_ignored():
+    notion = MagicMock()
+    bot = MagicMock()
+
+    _dispatch(_update("del:page-1", from_id=99999), notion, bot)
+
+    notion.pages.update.assert_not_called()
+    bot.edit_message_reply_markup.assert_not_called()
+    # Still answers the callback (to stop the spinner) but with a rejection.
+    bot.answer_callback_query.assert_called_once()
+    assert "Not authorized" in bot.answer_callback_query.call_args.args[1]

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/telegram.py": {
+      "includeFiles": "src/**"
+    }
+  }
+}


### PR DESCRIPTION
Each quote now carries inline buttons (Favorite toggle, Put back in cycle, Delete, Send another). Taps are handled by a new Vercel Python serverless function registered as the bot's webhook, since the cron job isn't running to catch callback queries.

- telegram.py: build_quote_keyboard (Favorite label reflects state); send_telegram threads an optional reply_markup.
- notion.py: get_favorite/set_favorite/clear_send_date/set_deleted; get_unsent_quotes excludes soft-deleted (Deleted == true) quotes.
- service.py: pick_and_send, the shared daily-send flow.
- run_daily_service.py: delegates to pick_and_send.
- api/telegram.py + vercel.json: webhook with secret-header + sender-id checks; handle_update dispatches fav/cycle/del/more and answers the callback to stop the spinner.
- tests: notion actions, keyboard labels/callback_data, and test_webhook.py dispatch + auth rejection. 31 passing.
- CLAUDE.md: webhook, Deleted property, TELEGRAM_WEBHOOK_SECRET, buttons.

Requires a Deleted checkbox in the Notion DB and the webhook deployed to Vercel with env vars set.